### PR TITLE
remove unnecessary apply

### DIFF
--- a/.changeset/beige-bottles-lie.md
+++ b/.changeset/beige-bottles-lie.md
@@ -1,0 +1,9 @@
+---
+"vite-plugin-css-class-name-extractor-for-purescript": patch
+---
+
+Remove unnecessary conditional running of the plugin
+
+This commit removes the apply: 'serve' configuration from the plugin to allow it to
+run in all Vite environments, not just development. This change was needed because
+CSS class name extraction is required for both development and production builds.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/*
 .spec-results
 .psc-ide-port
 .psci_modules
+example/dist/*

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,10 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/generated-docs/
+/.psc-package/
+/.psc*
+/.purs*
+/.psa*
+/.spago

--- a/example/packages.dhall
+++ b/example/packages.dhall
@@ -1,0 +1,105 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
+-------------------------------
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
+  with halogen-vdom.dependencies = [ "extra-dependency" ] # halogen-vdom.dependencies
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
+-------------------------------
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+-------------------------------
+-}
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20241207/packages.dhall
+        sha256:604d38aa63b48c64f22747beba7e198b7bde7a645de7f9ddac1d023fd4ea72a8
+
+in  upstream

--- a/example/spago.dhall
+++ b/example/spago.dhall
@@ -1,0 +1,17 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "my-project"
+, dependencies = [ "console", "effect", "prelude" ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,2 +1,2 @@
-import styles from '../output/Colors.Styles/index.js'
+import { wrapper } from '../output/Colors.Styles/index.js'
 console.log("hello world")

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,1 +1,2 @@
+import styles from '../output/Colors.Styles/index.js'
 console.log("hello world")

--- a/example/test/Main.purs
+++ b/example/test/Main.purs
@@ -1,0 +1,11 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Class.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍝"
+  log "You should add some tests."

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,6 @@ export function vitePluginCssClassNameExtractorForPureScript(config: Config): Pl
 
   return {
     name: "vite-plugin-css-class-name-extractor-for-purescript",
-    apply: 'serve',
     configResolved(s) {
       command = s.command
     },


### PR DESCRIPTION
  Remove unnecessary conditional running of the plugin
  
  This commit removes the apply: 'serve' configuration from the plugin to allow it to
  run in all Vite environments, not just development. This change was needed because
  CSS class name extraction is required for both development and production builds.
