### PR TITLE
fix a bug multiple pattern

### DIFF
--- a/.changeset/calm-singers-remember.md
+++ b/.changeset/calm-singers-remember.md
@@ -1,0 +1,9 @@
+---
+"vite-plugin-css-class-name-extractor-for-purescript": patch
+---
+
+Fix a bug where expandGlobsCwd does not work with multiple patterns
+
+Process patterns individually to avoid interference between patterns
+when matching files. This ensures correct rule application and
+namespace generation for each pattern.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "spago build && tsup",
     "publint": "publint",
     "changeset": "changeset",
-    "bump": "changeset version",
+    "bump": "changeset version && changeset tag && git push --tags",
     "publish": "pnpm build && changeset publish"
   },
   "keywords": [

--- a/test/Prebuild.purs
+++ b/test/Prebuild.purs
@@ -17,6 +17,7 @@ import Effect.Aff (Aff, error)
 import Effect.Aff as Aff
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Console (log)
 import Foreign.Object as FO
 import Node.Path (FilePath)
 import Test.Spec (Spec, describe, it)
@@ -69,6 +70,20 @@ runTest config init (TestM m) = do
 spec :: Spec Unit
 spec = do
   describe "PreBuild" do
+    describe "real file" do
+      it "should be writed file" do
+        let config = ClassNameExtractorConfig {
+          rules: FO.fromFoldable [
+            "example/src/components/*/*.module.css" /\ TransformRule { replacement: (TransformRuleReplacement "Components.\\1.\\2.Styles") },
+            "example/src/components/*.module.css" /\ TransformRule { replacement: (TransformRuleReplacement "Components.\\1.Styles") }
+          ]
+        }
+        (Tuple _ result) <- liftAff $  runTest config (Map.fromFoldable [
+          "example/src/components/Colors.module.css" /\ FileBody ".foo { display; flex; }"
+          ]) prebuild
+
+        result `shouldNotEqual` Map.empty
+
     it "should be writed file" do
       let config = ClassNameExtractorConfig {
         rules: FO.fromFoldable [ "foo.module.css" /\ TransformRule { replacement: (TransformRuleReplacement "foo") } ]


### PR DESCRIPTION
Fix a bug where expandGlobsCwd does not work with multiple patterns

Process patterns individually to avoid interference between patterns
when matching files. This ensures correct rule application and
namespace generation for each pattern.
